### PR TITLE
Add speed-measure-webpack-plugin

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -30,8 +30,7 @@
   - [Bundle contents](#bundle-contents)
   - [Code duplicates](#code-duplicates)
   - [Various tools](#various-tools)
-  - [Webpack analysis plugin](#webpack-analysis-plugin)
-- [Build-time audit tools](#build-time-audit-tools)
+- [Webpack build performance](#webpack-build-performance)
 - [Other web performance lists](#other-web-performance-lists)
 
 ## Built-in stuff
@@ -245,7 +244,7 @@ These tools help to find and remove duplicated code inside the bundles:
 
   <sup>(Image credits: `webpack-dashboard`)</sup>
 
-### Webpack analysis plugin
+## Webpack build performance
 
 The following tools show how to optimize your webpack build speed.
 

--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,7 @@
   - [Bundle contents](#bundle-contents)
   - [Code duplicates](#code-duplicates)
   - [Various tools](#various-tools)
+  - [Webpack analysis plugin](#webpack-analysis-plugin)
 - [Build-time audit tools](#build-time-audit-tools)
 - [Other web performance lists](#other-web-performance-lists)
 
@@ -243,6 +244,16 @@ These tools help to find and remove duplicated code inside the bundles:
   ![](https://camo.githubusercontent.com/3f5446837855aef7cb671a3c0ca6b9d351cf8045/687474703a2f2f692e696d6775722e636f6d2f714c3664584a642e706e67)
 
   <sup>(Image credits: `webpack-dashboard`)</sup>
+
+### Webpack analysis plugin
+
+The following tools show how to optimize your webpack build speed.
+
+- [`speed-measure-webpack-plugin`](https://www.npmjs.com/package/speed-measure-webpack-plugin) is a webpack plugin. During the build, the plugin measures your webpack build speed, giving an output like this:
+
+  ![](https://raw.githubusercontent.com/stephencookdev/speed-measure-webpack-plugin/master/preview.png)
+
+<sup>(Animation credits: `speed-measure-webpack-plugin`)</sup>
 
 ## Other web performance lists
 


### PR DESCRIPTION
Hey, love you work on webperf, just saw your `awesome-webpack-perf` :)

## Plugin: `speed-measure-webpack-plugin`

The plugin answers the question "how do you measure the performance of webpack plugins?"

Github: https://github.com/stephencookdev/speed-measure-webpack-plugin
NPM: https://www.npmjs.com/package/speed-measure-webpack-plugin
NPM trends: https://www.npmtrends.com/speed-measure-webpack-plugin

Test on my client project: https://twitter.com/choukmax/status/1235193406525181953

## Preview

![image](https://user-images.githubusercontent.com/2212144/87544034-0f319580-c6a6-11ea-90fe-be524fd0ced5.png)

PS: It would be interesting to manage the menu with [doctoc](https://github.com/thlorenz/doctoc) for example.